### PR TITLE
Fix for Windows Kernels above 19041

### DIFF
--- a/SMM Rootkit/SMMRootkit/WinTools.c
+++ b/SMM Rootkit/SMMRootkit/WinTools.c
@@ -332,6 +332,16 @@ STATIC BOOLEAN SetupOffsets(WinCtx *ctx)
       ctx->offsets.apl = 0x2f0;
       ctx->offsets.threadListEntry = 0x6b8;
     }
+      
+    if (ctx->ntBuild >= 19041)
+    {
+      ctx->offsets.apl = 0x448;
+      ctx->offsets.session = 0x558;
+      ctx->offsets.imageFileName = 0x5a8;
+      ctx->offsets.peb = 0x550;
+      ctx->offsets.threadListHead = 0x5e0;
+      ctx->offsets.threadListEntry = 0x4e8; //probably wrong, but it's not used anywhere
+    }
 
     break;
   default:


### PR DESCRIPTION
The offsets were never updated to reflect the kernel builds above 19041. 
Windows 10 Kernel offsets can be found using this website:
https://www.vergiliusproject.com/kernels/x64/Windows%2010%20|%202016